### PR TITLE
Fix missing jsonify import

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, g, session, redirect, url_for, flash, request
+from flask import Flask, g, session, redirect, url_for, flash, request, jsonify
 import sqlite3
 import functools
 from config import Config


### PR DESCRIPTION
## Summary
- add missing `jsonify` import

## Testing
- `python -m py_compile run.py app.py app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff48a6f688321a83e853e8ca1788e