### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Local database files
+inventory.db
+
+# OS generated files
+.DS_Store


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore Python bytecode, local DB files, and OS cruft

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff6811bd48321b163cde1242326be