### PR TITLE
Handle missing SECRET_KEY in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # WMS
 
+## Configuration
+
+- `SECRET_KEY` is used to sign Flask sessions. When `FLASK_ENV` is set to
+  `production` the application requires this variable to be defined. If it is
+  missing, a `RuntimeError` will be raised during startup. In development, a
+  fallback key is used.
+

--- a/config.py
+++ b/config.py
@@ -4,7 +4,11 @@ class Config:
     # المفتاح السري لـ Flask Sessions و flash messages.
     # في بيئة الإنتاج، استخدم مفتاحًا عشوائيًا ومعقدًا جدًا
     # ويفضل أن يتم تحميله من متغيرات البيئة.
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'your_another_super_secret_key_here_for_security_v6_123456789'
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+    if not SECRET_KEY:
+        if os.environ.get('FLASK_ENV') == 'production':
+            raise RuntimeError('SECRET_KEY environment variable must be set in production')
+        SECRET_KEY = 'your_another_super_secret_key_here_for_security_v6_123456789'
     
     # مدة صلاحية الجلسة بالثواني (ساعة واحدة)
     PERMANENT_SESSION_LIFETIME = 3600 


### PR DESCRIPTION
## Summary
- force `SECRET_KEY` to be provided when `FLASK_ENV=production`
- describe this configuration in the README

## Testing
- `python -m py_compile config.py`
- `python -m py_compile app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff802381483219e797aa924d34781