### PR TITLE
Add pytest and basic route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # WMS
 
+
+## Running Tests
+
+The project uses `pytest`. After installing the dependencies, run:
+
+```bash
+pytest
+```
+
+This will execute the authentication and product management tests using a temporary database.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import sqlite3
+import os
+import pytest
+
+from app import create_app
+from config import Config
+import database
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    Config.DATABASE = str(db_path)
+
+    # patch database connection to use temporary path
+    orig_connect = sqlite3.connect
+    def connect_override(*args, **kwargs):
+        return orig_connect(str(db_path))
+    monkeypatch.setattr(database, 'sqlite3', sqlite3)
+    monkeypatch.setattr(database.sqlite3, 'connect', connect_override)
+    database.init_db()
+
+    app = create_app()
+    app.config.update({'TESTING': True, 'WTF_CSRF_ENABLED': False})
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,16 @@
+import sqlite3
+from config import Config
+
+
+def test_login_logout(client):
+    # Successful login
+    resp = client.post('/auth/login', data={'username': 'admin', 'password': 'adminpass'}, follow_redirects=True)
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get('user_id') is not None
+
+    # Logout
+    resp = client.get('/auth/logout', follow_redirects=True)
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert 'user_id' not in sess

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,49 @@
+import sqlite3
+from config import Config
+
+
+def setup_inventory():
+    conn = sqlite3.connect(Config.DATABASE)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO racks (name) VALUES ('R1')")
+    rack_id = cur.lastrowid
+    cur.execute("INSERT INTO bins (name, rack_id) VALUES ('B1', ?)", (rack_id,))
+    bin_id = cur.lastrowid
+    cur.execute("INSERT INTO categories (name) VALUES ('عام')")
+    category_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return rack_id, bin_id, category_id
+
+
+def test_add_and_update_product(client):
+    rack_id, bin_id, category_id = setup_inventory()
+
+    client.post('/auth/login', data={'username': 'admin', 'password': 'adminpass'})
+
+    # Add product
+    resp = client.post('/products/add', data={
+        'product_code': 'P001',
+        'rack_id': str(rack_id),
+        'bin_id': str(bin_id),
+        'quantity': '5',
+        'category_id': str(category_id)
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(Config.DATABASE)
+    product = conn.execute('SELECT id, quantity FROM products WHERE product_code=?', ('P001',)).fetchone()
+    conn.close()
+    assert product is not None
+    product_id = product[0]
+
+    # Increase quantity
+    resp = client.post(f'/products/update_quantity/{product_id}', data={
+        'action': 'increase',
+        'change_amount': '3'
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    conn = sqlite3.connect(Config.DATABASE)
+    new_qty = conn.execute('SELECT quantity FROM products WHERE id=?', (product_id,)).fetchone()[0]
+    conn.close()
+    assert new_qty == 8


### PR DESCRIPTION
## Summary
- configure pytest
- add fixtures and tests for auth and product routes
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff847b98c83219f7267de276c6d3c